### PR TITLE
refactor: memoize `Editor` component

### DIFF
--- a/app/(main)/(routes)/documents/[documentId]/page.tsx
+++ b/app/(main)/(routes)/documents/[documentId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMutation, useQuery } from "convex/react";
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
 
 import { Cover } from "@/components/cover";
 import { Toolbar } from "@/components/toolbar";
@@ -18,10 +17,7 @@ interface DocumentIdPageProps {
 }
 
 const DocumentIdPage = ({ params }: DocumentIdPageProps) => {
-  const Editor = useMemo(
-    () => dynamic(() => import("@/components/editor"), { ssr: false }),
-    [],
-  );
+  const Editor = dynamic(() => import("@/components/editor"), { ssr: false });
 
   const document = useQuery(api.documents.getById, {
     documentId: params.documentId,

--- a/app/(public)/(routes)/preview/[documentId]/page.tsx
+++ b/app/(public)/(routes)/preview/[documentId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMutation, useQuery } from "convex/react";
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
 
 import { Cover } from "@/components/cover";
 import { Toolbar } from "@/components/toolbar";
@@ -17,10 +16,7 @@ interface DocumentIdPageProps {
 }
 
 const DocumentIdPage = ({ params }: DocumentIdPageProps) => {
-  const Editor = useMemo(
-    () => dynamic(() => import("@/components/editor"), { ssr: false }),
-    [],
-  );
+  const Editor = dynamic(() => import("@/components/editor"), { ssr: false });
 
   const document = useQuery(api.documents.getById, {
     documentId: params.documentId,

--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -8,7 +8,7 @@ import { BlockNoteView } from "@blocknote/mantine";
 import { useCreateBlockNote } from "@blocknote/react";
 import { useAction, useConvexAuth } from "convex/react";
 import { useTheme } from "next-themes";
-import { useEffect } from "react";
+import { memo, useEffect } from "react";
 import { toast } from "sonner";
 
 import { customSchema } from "@/components/editor/schema";
@@ -95,4 +95,4 @@ const Editor = ({
   );
 };
 
-export default Editor;
+export default memo(Editor);


### PR DESCRIPTION
Memoize `Editor` component by default (appears to improve first page load slightly)