### PR TITLE
refactor: initialize language runners only when necessary

### DIFF
--- a/apps/eurekapad/components/editor/code/code-block.tsx
+++ b/apps/eurekapad/components/editor/code/code-block.tsx
@@ -157,8 +157,8 @@ export const CodeBlock: FC<ReactCustomBlockRenderProps<CodeBlockConfig, InlineCo
     [getUploadUrl, editorContext],
   )
 
-  const { runner: pythonRunner, loaded: pythonLoaded } = usePythonRunner()
-  const { runner: jsRunner, loaded: jsLoaded } = useJSRunner()
+  const { runner: pythonRunner, loaded: pythonLoaded } = usePythonRunner(language)
+  const { runner: jsRunner, loaded: jsLoaded } = useJSRunner(language)
 
   const handleInputChange = useCallback(
     ({ code, language, height }: { code?: string; language?: string; height?: number }) => {

--- a/apps/eurekapad/hooks/use-js-runner.tsx
+++ b/apps/eurekapad/hooks/use-js-runner.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react'
 
 import { SingletonJSRunner } from '@/lib/singleton-js-runner'
 
-export const useJSRunner = () => {
+export const useJSRunner = (language: string) => {
   const [runner, setRunner] = useState<SingletonJSRunner | null>(null)
   const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
+    if (language !== 'javascript' && language !== 'typescript') return
     const runner = SingletonJSRunner.getInstance()
 
     setRunner(runner)

--- a/apps/eurekapad/hooks/use-python-runner.tsx
+++ b/apps/eurekapad/hooks/use-python-runner.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react'
 
 import { SingletonPythonRunner } from '@/lib/singleton-python-runner'
 
-export const usePythonRunner = () => {
+export const usePythonRunner = (language: string) => {
   const [runner, setRunner] = useState<SingletonPythonRunner | null>(null)
   const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
+    if (language !== 'python') return
     const runner = SingletonPythonRunner.getInstance()
 
     setRunner(runner)


### PR DESCRIPTION
This PR changes the behaviour of loading the runners, so the runners are only initialized when a code block with their specified programs is present

I think an even more efficient way would be to only initialize the runners when we're actually running the programs
Will determine how difficult/feasible this is